### PR TITLE
Fix RepeatedKFold and RepeatedStratifiedKFold __repr__ method

### DIFF
--- a/Phase 1/scikit-learn/sklearn/model_selection/_split.py
+++ b/Phase 1/scikit-learn/sklearn/model_selection/_split.py
@@ -1162,6 +1162,9 @@ class _RepeatedSplits(metaclass=ABCMeta):
         cv = self.cv(random_state=rng, shuffle=True,
                      **self.cvargs)
         return cv.get_n_splits(X, y, groups) * self.n_repeats
+        
+    def __repr__(self):
+        return _build_repr(self)
 
 
 class RepeatedKFold(_RepeatedSplits):


### PR DESCRIPTION
Added __repr__ method to _RepeatedSplits class to fix string representation for RepeatedKFold and RepeatedStratifiedKFold classes.

This ensures that both classes display their parameters correctly when using repr(), as required in the task instructions.